### PR TITLE
Buildroot cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,7 @@ addons:
 
 cache:
   directories:
-    - $HOME/output/host
-    - $HOME/output/build/host-autoconf-2.69
-    - $HOME/output/build/host-automake-1.15
-    - $HOME/output/build/host-binutils-2.24
-    - $HOME/output/build/host-gcc-initial-4.8.4
-    - $HOME/output/build/host-gcc-final-4.8.4
-    - $HOME/output/build/host-libtool-2.4.5
-    - $HOME/output/build/host-m4-1.4.17
-    - $HOME/output/build/host-gmp-6.0.0a
-    - $HOME/output/build/host-mpc-1.0.2
-    - $HOME/output/build/host-mpfr-3.1.2
+    - $HOME/.buildroot-ccache
 
 script:
-    - mkdir -p $HOME/output
-    - ln -s $HOME/output buildroot/output
-    - find buildroot/output
-    - make -s
-    - ls -la
+    - make CCACHE_ENABLE=1 -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ addons:
 
 cache:
   directories:
+    - $HOME/.buildroot-dl
     - $HOME/.buildroot-ccache
 
 script:
+    - mkdir -p $HOME/.buildroot-dl
+    - ln -s $HOME/.buildroot-dl buildroot/dl
     - make CCACHE_ENABLE=1 -s

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,38 @@ clean: clean-buildroot
 
 distclean: distclean-buildroot
 
+
 GREEN = \e[01;32m
 NC = \e[00m
 INFO = @/bin/echo -e "$(GREEN)*** Make: $@$(NC)"
 
+# internal variables
+_defconfig = "develer_develboard_defconfig"
+_opt_ccache = "BR2_CCACHE=y"
+
+# use `make CCACHE_ENABLE=[1|0]` to enable/disable ccache
+CCACHE_ENABLE ?= $(shell grep -q "$(_opt_ccache)" buildroot/configs/$(_defconfig) && echo 1 || echo 0)
+
+# don't pass special options to sub-makes (e.g. CCACHE_ENABLE=1)
+MAKEOVERRIDES := $(filter-out CCACHE_ENABLE=%,$(MAKEOVERRIDES))
+
 
 build-buildroot:
 	$(INFO)
-	$(MAKE) -C $(@:build-%=%) develer_develboard_defconfig
+	$(MAKE) -C $(@:build-%=%) $(_defconfig)
+ifeq ($(CCACHE_ENABLE),0)
+	# ccache disabled
+	@if grep -q "$(_opt_ccache)" $(@:build-%=%)/.config; then \
+		sed -i "/$(_opt_ccache)/d" $(@:build-%=%)/.config; \
+		yes "" | $(MAKE) -C $(@:build-%=%) oldconfig; \
+	fi
+else
+	# ccache enabled
+	@if ! grep -q "$(_opt_ccache)" $(@:build-%=%)/.config; then \
+		echo "$(_opt_ccache)" >> $(@:build-%=%)/.config; \
+		yes "" | $(MAKE) -C $(@:build-%=%) oldconfig; \
+	fi
+endif
 	$(MAKE) -C $(@:build-%=%)
 
 clean-buildroot:


### PR DESCRIPTION
I don't cache host packages anymore because now an external toolchain is used and ccache is enabled. The actual compilation is yet to be tested.
