### PR TITLE
barebox and kernel: configure eeprom to be read-only

### DIFF
--- a/buildroot/board/develer/develboard/barebox-2015.10.0-patches/barebox-2015.10.0-0015-barebox-disable-eeprom-write.patch
+++ b/buildroot/board/develer/develboard/barebox-2015.10.0-patches/barebox-2015.10.0-0015-barebox-disable-eeprom-write.patch
@@ -1,0 +1,24 @@
+From 8851e3f641c06bf9f756b4e3a43fdc8cf649b0ac Mon Sep 17 00:00:00 2001
+From: Pietro Lorefice <pietro@develer.com>
+Date: Fri, 27 Nov 2015 15:57:31 +0100
+Subject: [PATCH] barebox: disable eeprom write
+
+---
+ arch/arm/boards/sama5d4_xplained/sama5d4_xplained.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boards/sama5d4_xplained/sama5d4_xplained.c b/arch/arm/boards/sama5d4_xplained/sama5d4_xplained.c
+index f152726..47e3634 100644
+--- a/arch/arm/boards/sama5d4_xplained/sama5d4_xplained.c
++++ b/arch/arm/boards/sama5d4_xplained/sama5d4_xplained.c
+@@ -291,6 +291,7 @@ struct qt1070_platform_data qt1070_pdata = {
+ static struct at24_platform_data at24mac402_eeprom = {
+ 	.byte_len = SZ_2K / 8,
+ 	.page_size = 16,
++	.flags = AT24_FLAG_READONLY,
+ };
+ 
+ /**
+-- 
+1.9.1
+

--- a/buildroot/board/develer/develboard/linux-linux4sam_4.7-patches/linux-linux4sam_4.7-0010-configure-internal-eeprom-as-read-only.patch
+++ b/buildroot/board/develer/develboard/linux-linux4sam_4.7-patches/linux-linux4sam_4.7-0010-configure-internal-eeprom-as-read-only.patch
@@ -1,0 +1,24 @@
+From 9cf8ad2053ad1411d92adf2641cfcb4b103d21e2 Mon Sep 17 00:00:00 2001
+From: Pietro Lorefice <pietro@develer.com>
+Date: Fri, 27 Nov 2015 17:03:57 +0100
+Subject: [PATCH] configure internal eeprom as read-only
+
+---
+ arch/arm/boot/dts/at91-sama5d4_develboard.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/boot/dts/at91-sama5d4_develboard.dts b/arch/arm/boot/dts/at91-sama5d4_develboard.dts
+index dea6b37..4b17a38 100644
+--- a/arch/arm/boot/dts/at91-sama5d4_develboard.dts
++++ b/arch/arm/boot/dts/at91-sama5d4_develboard.dts
+@@ -111,6 +111,7 @@
+ 					compatible = "24c02";
+ 					reg = <0x50>;
+ 					pagesize = <16>;
++					read-only;
+ 				};
+ 
+ 				/**
+-- 
+1.9.1
+


### PR DESCRIPTION
Per evitare che l'utente vada "accidentalmente" a sovrascrivere i dati del collaudo e in particolare la revisione hardware della scheda
